### PR TITLE
eve.once()

### DIFF
--- a/e.html
+++ b/e.html
@@ -28,6 +28,9 @@
         eve.on("hit/*/leg", f4 = function () {
             log("   Ouch!");
         });
+        eve.once("hit", function () {
+            log("   You scoundrel!");
+        })(-1);
         
         // fire events
         log("In your face!");

--- a/eve.js
+++ b/eve.js
@@ -271,6 +271,30 @@
         }
     };
     /*\
+     * eve.once
+     [ method ]
+     **
+     * Binds given event handler with a given name to only run once then unbind itself.
+     | eve.once("login", f);
+     | eve("login"); // triggers f
+     | eve("login"); // no listeners
+     * Use @eve to trigger the listener.
+     **
+     > Arguments
+     **
+     - name (string) name of the event, dot (`.`) or slash (`/`) separated, with optional wildcards
+     - f (function) event handler function
+     **
+     = (function) same return function as @eve.on
+    \*/
+    eve.once = function (name, f) {
+        var f2 = function () {
+            f.apply(this, arguments);
+            eve.unbind(name, f2);
+        };
+        return eve.on(name, f2);
+    };
+    /*\
      * eve.version
      [ property (string) ]
      **


### PR DESCRIPTION
Hi Dmitry,

I needed a "fire once and forget" method for eve, mainly to be used as a post-login callback queue.
I added it as eve.once() but the name can change (I know jQuery uses .one() but that looks a bit too similar to .on() for me).

I also made some tweaks to the documentation and fixed up an undeclared jj variable in eve.unbind()

Cheers,

Gil
