### PR TITLE
Bug fix for eve.once()

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -289,8 +289,8 @@
     \*/
     eve.once = function (name, f) {
         var f2 = function () {
-            f.apply(this, arguments);
             eve.unbind(name, f2);
+            return f.apply(this, arguments);
         };
         return eve.on(name, f2);
     };


### PR DESCRIPTION
Clearly I hadn't tested .once() enough the first time, it wasn't passing along the event handler return value.
