### PR TITLE
New once function did not pass on return values

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -1,12 +1,12 @@
 // ┌──────────────────────────────────────────────────────────────────────────────────────┐ \\
-// │ Eve 0.3.2 - JavaScript Events Library                                                │ \\
+// │ Eve 0.3.3 - JavaScript Events Library                                                │ \\
 // ├──────────────────────────────────────────────────────────────────────────────────────┤ \\
 // │ Copyright (c) 2008-2011 Dmitry Baranovskiy (http://dmitry.baranovskiy.com/)          │ \\
 // │ Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) license. │ \\
 // └──────────────────────────────────────────────────────────────────────────────────────┘ \\
 
 (function (glob) {
-    var version = "0.3.2",
+    var version = "0.3.3",
         has = "hasOwnProperty",
         separator = /[\.\/]/,
         wildcard = "*",
@@ -289,8 +289,10 @@
     \*/
     eve.once = function (name, f) {
         var f2 = function () {
-            f.apply(this, arguments);
+            var res = f.apply(this, arguments);
             eve.unbind(name, f2);
+
+            return res;
         };
         return eve.on(name, f2);
     };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url"   : "http://dmitry.baranovskiy.com"
     },
 
-    "version" : "0.3.0",
+    "version" : "0.3.3",
 
     "main"    : "./eve.js",
 


### PR DESCRIPTION
Use return values from event handlers quite a bit, the new once function masked the results of it's handler so tweaked it.

No changes made to eve.min.js so I guess that will need to be repacked...
