### PR TITLE
add support for AMD

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -306,5 +306,6 @@
     eve.toString = function () {
         return "You are running Eve " + version;
     };
-    (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (glob.eve = eve);
+    (typeof module != "undefined" && module.exports) ? (module.exports = eve) :
+        (typeof define != "undefined" ? (define('eve', [], function() { return eve; })) : (glob.eve = eve));
 })(this);


### PR DESCRIPTION
This allows eve to be used by requirejs or other commonjs client side libraries. Nodejs doesn't support AMD in a consistent way to requirejs so I couldn't replace the typeof module != 'undefined' check.

in node
define('eve', [], function() { return eve; })

equates to
var eve = require('eve').eve;
