### PR TITLE
Adjust behaviour of eve.f to match eve

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -198,7 +198,7 @@
      = (function) possible event handler function
     \*/
     eve.f = function (name, scope) {
-        var fargs = [].slice.call(arguments, 0);
+        var fargs = [name, scope].concat([].slice.call(arguments, 2));
         return function () {
             eve.apply(null, fargs.concat([].slice.call(arguments, 0)));
         };


### PR DESCRIPTION
eve.f doesn't allow the use of the `scope` argument of eve.

This change adjusts the behaviour of eve.f to match that of eve, by allowing both `name` and `scope` arguments.
