### PR TITLE
strict comparison on typeof define

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -367,5 +367,5 @@
     eve.toString = function () {
         return "You are running Eve " + version;
     };
-    (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define != "undefined" ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
+    (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define === "function" && define.amd ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
 })(window || this);


### PR DESCRIPTION
This ensures compatibility with the r.js optimizer's namespace functionality, and it's just good practice :]
