### PR TITLE
Fixed a bug that did not work in node.

### DIFF
--- a/eve.js
+++ b/eve.js
@@ -368,4 +368,4 @@
         return "You are running Eve " + version;
     };
     (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define === "function" && define.amd ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
-})(window || this);
+})(this.window || this);


### PR DESCRIPTION
When JavaScript engine find undefined variables, throw ReferenceError.
but undefined properties does not.
There is not "window" variable in node.
so, we must change variable to property.
