### PR TITLE
Eve: fix for contexts that supports modules

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,2 @@
+[0209/184703:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
+[0209/184703:ERROR:node_debugger.cc(86)] Cannot start debugger server

--- a/debug.log
+++ b/debug.log
@@ -1,2 +1,0 @@
-[0209/184703:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
-[0209/184703:ERROR:node_debugger.cc(86)] Cannot start debugger server

--- a/eve.js
+++ b/eve.js
@@ -445,5 +445,6 @@
     eve.toString = function () {
         return "You are running Eve " + version;
     };
+    glob.eve = eve;
     (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define === "function" && define.amd ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
-})(this);
+})(window || this);


### PR DESCRIPTION
Hi -

I ran into issues when running Snap.svg inside of Electron, the popular node.js+chromium distribution. The issue is that Electron has modules support via node.js, and this cause eve to not get exported correctly. This small change allows it to run in both web contexts and inside of Electron.

Cheers,
-Courtland
